### PR TITLE
[refactor] basis_keys to list

### DIFF
--- a/equiformer_pytorch/equiformer_pytorch.py
+++ b/equiformer_pytorch/equiformer_pytorch.py
@@ -1057,7 +1057,7 @@ class Equiformer(nn.Module):
 
     @basis.setter
     def basis(self, basis):
-        self.basis_keys = basis.keys()
+        self.basis_keys = list(basis.keys())
 
         for k, v in basis.items():
             self.register_buffer(f'basis:{k}', v)


### PR DESCRIPTION
Cast basis keys to list so it can be serialised in torch.save()

If not, this happens (tested on PyTorch 2.5.1+cu124)

> torch.save(model, "test.pt")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/hilbert/miniconda3/envs/.../lib/python3.11/site-packages/torch/serialization.py", line 850, in save
    _save(
  File "/home/hilbert/miniconda3/envs/.../lib/python3.11/site-packages/torch/serialization.py", line 1088, in _save
    pickler.dump(obj)
TypeError: cannot pickle 'dict_keys' object